### PR TITLE
Accelerometer is now working properly

### DIFF
--- a/CCS/accelDemo/main.c
+++ b/CCS/accelDemo/main.c
@@ -76,17 +76,11 @@ void main(void) {
     // Set abort conditions: Exits WISP_doRFID() when the following events happen:
     WISP_setAbortConditions(CMD_ID_READ | CMD_ID_WRITE | CMD_ID_ACK);
 
-//    // Debug output
-//	BITSET(PDIR_AUX3 , PIN_AUX3);
-//	__delay_cycles(50);
-//	BITCLR(P1OUT , PIN_AUX3);
-//	__delay_cycles(50);
-//	BITSET(P1OUT , PIN_AUX3);
-//	__delay_cycles(50);
 
 	// Accelerometer power up sequence
-	BITSET(P4SEL1 , PIN_ACCEL_EN);
-	BITSET(P4SEL0 , PIN_ACCEL_EN);
+	BITCLR(POUT_ACCEL_EN , PIN_ACCEL_EN);
+	__delay_cycles(100);
+	BITSET(POUT_ACCEL_EN , PIN_ACCEL_EN);
 
 	accelOut.x = 1;
 	accelOut.y = 1;
@@ -107,7 +101,7 @@ void main(void) {
 	while(accelOut.x != 0xAD){
 		__delay_cycles(5);
 		wispData.epcBuf[9] = accelOut.x;
-		WISP_doRFID();
+//		WISP_doRFID();
 
 		ACCEL_readID(&accelOut);
 
@@ -121,7 +115,7 @@ void main(void) {
 	while((accelOut.x & 192) != 0x40){
 		__delay_cycles(5);
 		wispData.epcBuf[9] = accelOut.x;
-		WISP_doRFID();
+//		WISP_doRFID();
 		ACCEL_readStat(&accelOut);
 	}
 	__delay_cycles(5);

--- a/CCS/wisp-base/config/pin-assign.h
+++ b/CCS/wisp-base/config/pin-assign.h
@@ -210,7 +210,7 @@
     PJDIR = PIN_LED2;\
     P2DIR = PIN_TX;\
     P3DIR = 0x00;\
-    P4DIR = PIN_ACCEL_CS | PIN_LED1;\
+    P4DIR = PIN_ACCEL_CS | PIN_LED1 | PIN_ACCEL_EN;\
 
 #endif /* ~__ASSEMBLER__ */
 


### PR DESCRIPTION
This is the pull request for the master branch. Just one thing, since the ADXL 362 cannot be sampled over 400 (I think) and in 640 version of the firmware the DCO is 4 time faster so the ADXL does not work as perfect as in 160 which I think is not a big deal.
