### PR TITLE
Make WISP more power efficient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-*~
+*~	# backup/temp files/folders
+.dvt/ 	# TI EnergyTrace folders

--- a/CCS/wisp-base/RFID/Timer0A1_ISR.asm
+++ b/CCS/wisp-base/RFID/Timer0A1_ISR.asm
@@ -52,7 +52,12 @@ CPU_is_off:		;[]i.e. we're still in latch mode. restart the RX State Machine. Tw
 
 	BIC.B	#(CM_2+CCIE), &TA0CCTL0	;[] disable capture and interrupts by capture-compare unit
 	BIC		#(CCIFG),	TA0CCTL0	;[] clear the interrupt flag
-	BIS		#(SCG1+OSCOFF+CPUOFF+GIE), SR_SP_OFF(SP);[] put tag back into LPM4
+
+	NOP
+	BIC		#(SMCLKREQEN+MCLKREQEN+ACLKREQEN), CSCTL6	;[] disable all clk requests, they prevent LPM4
+	NOP
+	BIS		#(SCG0+SCG1+OSCOFF+CPUOFF+GIE), SR			;[] put tag back into LPM4
+	NOP
 
 	POPM.A #1, R15
 	RETI							;[5] return from interrupt
@@ -67,7 +72,10 @@ Wakeup_Proc:
 	
 	MOV		#(FALSE), &isDoingLowPwrSleep ;[] clear that flag!
 
-	BIC		#(SCG1+OSCOFF+CPUOFF+GIE), SR_SP_OFF(SP);[] take tag out of LPM4
+	NOP
+	BIC		#(SCG0+SCG1+OSCOFF+CPUOFF+GIE), SR;[] take tag out of LPM4
+	NOP
+
 	POPM.A #1, R15
 	RETI							;[5] return from interrupt
 

--- a/CCS/wisp-base/RFID/WISP_doRFID.asm
+++ b/CCS/wisp-base/RFID/WISP_doRFID.asm
@@ -115,6 +115,9 @@ keepDoingRFID:
 	MOV.B	#PIN_RX,	&PRXIE		;[] Enable Port1 interrupt
 
 	; @todo Shouldn't we sleep_till_full_power here? Where else could that happen?
+	NOP
+	BIC		#(SMCLKREQEN+MCLKREQEN+ACLKREQEN), CSCTL6	;[] disable all clk requests, they prevent LPM4
+	NOP
 	BIS		#(GIE+SCG1+SCG0+OSCOFF+CPUOFF), SR			;[] sleep! (LPM4 | GIE)
 	NOP
 


### PR DESCRIPTION
Hi,

I would like to use this pull-request to start a conversation about optimizing the WISP power consumption.
Untill now I have made the already present LPM calls function as expected. This seems to improve the readrate.

Within the assembly code I see a lot of commented command sequenses annotated with `@us_change`, could anyone ellaborate on these and other annotations?

Looking forwared to your responses!

--Ivar