### PR TITLE
Get rid of RTCAL_OFFS to get exact RTCAL value + BlockWrite support.

### DIFF
--- a/CCS/simpleAckDemo/main.c
+++ b/CCS/simpleAckDemo/main.c
@@ -75,7 +75,7 @@ void main(void) {
   WISP_registerCallback_BLOCKWRITE(&my_blockWriteCallback);
   
   // Initialize BlockWrite data buffer.
-  uint16_t brw_array[6] = {0};
+  uint16_t bwr_array[6] = {0};
   RWData.bwrBufPtr = bwr_array;
   
   // Get access to EPC, READ, and WRITE data buffers

--- a/CCS/simpleAckDemo/main.c
+++ b/CCS/simpleAckDemo/main.c
@@ -43,7 +43,18 @@ void my_writeCallback (void) {
 
  */
 void my_blockWriteCallback  (void) {
-  asm(" NOP");
+  wispData.epcBuf[0]  = (wispData.blockWriteBufPtr[0] >> 8)  & 0xFF;
+  wispData.epcBuf[1]  = (wispData.blockWriteBufPtr[0])  & 0xFF;
+  wispData.epcBuf[2]  = (wispData.blockWriteBufPtr[1] >> 8)  & 0xFF;
+  wispData.epcBuf[3]  = (wispData.blockWriteBufPtr[1])  & 0xFF;
+  wispData.epcBuf[4]  = (wispData.blockWriteBufPtr[2] >> 8)  & 0xFF;
+  wispData.epcBuf[5]  = (wispData.blockWriteBufPtr[2])  & 0xFF;
+  wispData.epcBuf[6]  = (wispData.blockWriteBufPtr[3] >> 8)  & 0xFF;
+  wispData.epcBuf[7]  = (wispData.blockWriteBufPtr[3])  & 0xFF;
+  wispData.epcBuf[8]  = (wispData.blockWriteBufPtr[4] >> 8)  & 0xFF;
+  wispData.epcBuf[9]  = (wispData.blockWriteBufPtr[4])  & 0xFF;
+  wispData.epcBuf[10] = (wispData.blockWriteBufPtr[5] >> 8)  & 0xFF;
+  wispData.epcBuf[11] = (wispData.blockWriteBufPtr[5])  & 0xFF;
 }
 
 
@@ -63,6 +74,10 @@ void main(void) {
   WISP_registerCallback_WRITE(&my_writeCallback);
   WISP_registerCallback_BLOCKWRITE(&my_blockWriteCallback);
   
+  // Initialize BlockWrite data buffer.
+  uint16_t brw_array[6] = {0};
+  RWData.bwrBufPtr = bwr_array;
+  
   // Get access to EPC, READ, and WRITE data buffers
   WISP_getDataBuffers(&wispData);
   
@@ -71,18 +86,18 @@ void main(void) {
   WISP_setAbortConditions(CMD_ID_READ | CMD_ID_WRITE /*| CMD_ID_ACK*/);
   
   // Set up EPC
-  wispData.epcBuf[0] = 0x05; // WISP version
-  wispData.epcBuf[1] = *((uint8_t*)INFO_WISP_TAGID+1); // WISP ID MSB
-  wispData.epcBuf[2] = *((uint8_t*)INFO_WISP_TAGID); // WISP ID LSB
-  wispData.epcBuf[3] = 0x33;
-  wispData.epcBuf[4] = 0x44;
-  wispData.epcBuf[5] = 0x55;
-  wispData.epcBuf[6] = 0x66;
-  wispData.epcBuf[7] = 0x77;
-  wispData.epcBuf[8] = 0x88;
-  wispData.epcBuf[9] = 0x99;
-  wispData.epcBuf[10]= 0xAA;
-  wispData.epcBuf[11]= 0xBB;
+  wispData.epcBuf[0] = 0x00; // WISP version
+  wispData.epcBuf[1] = 0x00; //*((uint8_t*)INFO_WISP_TAGID+1); // WISP ID MSB
+  wispData.epcBuf[2] = 0x00; //*((uint8_t*)INFO_WISP_TAGID); // WISP ID LSB
+  wispData.epcBuf[3] = 0x00;
+  wispData.epcBuf[4] = 0x00;
+  wispData.epcBuf[5] = 0x00;
+  wispData.epcBuf[6] = 0x00;
+  wispData.epcBuf[7] = 0x00;
+  wispData.epcBuf[8] = 0x00;
+  wispData.epcBuf[9] = 0x00;
+  wispData.epcBuf[10]= 0x00;
+  wispData.epcBuf[11]= 0x00;
   
   // Talk to the RFID reader.
   while (FOREVER) {

--- a/CCS/wisp-base/RFID/RX_ISR.asm
+++ b/CCS/wisp-base/RFID/RX_ISR.asm
@@ -1,185 +1,113 @@
-	.cdecls C, LIST, "../globals.h"
 ;/************************************************************************************************************************************
-;* OLD DATA. TODO.                                     PORT 1 ISR (Starting a Command Receive)                                       *
-;* Theory: RX ISR Will perform two different functions:                                                                              *
-;*       - #1: RX ISR triggers on falling edge that indicates the beginning of a delimiter. It will then reset TA0R, set itself up to*
-;*               trigger on rising edge for next interrupt (#2).                                                                     *
-;*       - #2: RX ISR triggers on rising edge that indicates the end of a delimiter. It then sets up TA1 Capture for triggering the  *
-;*               remaining data bits.																								 *
-;*           Assumption: R5 != on entry. This is used for logic testing purposes.                                                    *
-;*           Note: May trigger on power down from the reader                                                                         *
-;*           Note: If incorrect delimiter is found, then the ISR sets itself up to look for another delimiter                        *
-;* Timing Measurements: measurement is 4 less than actual value. rev0.3 board demos >99% of Delims(todo: verify this num with cRIO)  *
-;*						within [11..15]us ->@12MHz->[132..186]+4.
-;* 			-#1: startEntry: 		6+24+5 -> 35 -> 2.91us (ENTRY+PROC+EXIT)														 *
-;* 			-#2: exitEntry:			6+36+5 -> 47 -> 3.92us (ENTRY+PROC+EXIT)														 *
-;* 			-#X: incorrDelimEntry: 	6+32+5 -> 43 -> 3.58us (ENTRY+PROC+EXIT)														 *
-;* Note: Only will exit LPM0/4 if a correct delimiter is found. Thus the main code doesn't execute until the delimiter is found.	 *
-;* @todo	redocument the new Port1 ISR
-;*************************************************************************************************************************************/
+;*                                           PORT 1 ISR (Starting a Command Receive)
+;*   Here starts the hard real time stuff.
+;*   MCLK is 16 MHz (See Clocking.asm) -> 0.0625 us per cycle
+;*   Entering ISR takes 6 cycles (4.5.1.5.1) + Time needed to wake up from LPM1 (~4 us)
+;*   Each BIT.B takes 5-1 cycles (4.5.1.5.4)
+;*   Each JNZ or JZ takes 2 cycles regardless whether it is taken or not (4.5.1.5.3)
+;*   Start this ISR at t = 0.375 us + wake up time (~4 us?) TODO: Find out  this exact wakeup time or why we have this gap.
+;*   Listed instruction cycles are taken from MSP430FR5969 User Guide (SLAU367F).
+;*
+;*   Purpose:
+;*   This ISR kicks in on a falling edge and tries to find the rising edge marking the end of the delimiter of a PREAMBLE/FRAME-SYNC.
+;*   After that, we disable PORT1 interrupts and setup Timer0A0.
+;*   In the worst case (readers with 6.25 Tari), we only have 0.475*6.25 us = 47 clock cycles) before the falling edge of data-0.
+;*   Then we quickly return from this interrupt and wait for Timer0A0 to wake us up on the data-0 falling edge.
+;*   An ASCII drawing of the situation can be found below:
+;*
+;*   |   data-0  |           RTCAL             |
+;*   /-----\_____/------------------------\____/   - Wave form
+;*
+;*************************************************************************************************************************************
 
-;Listed Timing is taken at the end of the cycles (i.e. it could be up to 4 cycles less!)
-; would need a function generator to time this better to get sub instruction resolution.
+	.cdecls C, LIST, "../globals.h"
 	.retain
 	.retainrefs
 
-RX_ISR:							;[X]t=2.24us into delim (measured @ 12.84MHz) -> each check is 6cyc -> .46875
-	;*********************************************************************************************************************************
-	; TOO EARLY (DELIM <6us)
-	;*********************************************************************************************************************************
-	;;;;;;@Saman compatibility with other readers
-	;; MCLK is 8MHz
-	;; about 1us to enter the ISR
-	;; For each of BIT.B 3 Cycles
-	;; For each JNZ or JZ not taken 2 Cycles
-	;; For JNZ or JZ taken 3 or 4 cycles
-;	DEBUG
-;	BIS.B 	#PIN_LED, 	&PLEDOUT
-	BIT.B	#PIN_RX,	&PRXIN		;[3]t=3.19..3.43us	(on the src fetch cycle)
-	JNZ		badDelim				;[2]
-	BIT.B	#PIN_RX,	&PRXIN		;[3]t=4.41..4.66us	""
-	JNZ		badDelim				;[2]
-	BIT.B	#PIN_RX,	&PRXIN		;[3]t=5.64..5.88us
-	JNZ		badDelim				;[2]
+RX_ISR:
+	BIT.B   #PIN_RX, &PRXIN                             ;[4]
+	JNZ     badDelim                                    ;[2]
+	BIT.B   #PIN_RX, &PRXIN                             ;[4]
+	JNZ     badDelim                                    ;[2]
+	BIT.B   #PIN_RX, &PRXIN                             ;[4]
+	JNZ     badDelim                                    ;[2]
+	BIT.B   #PIN_RX, &PRXIN                             ;[4]
+	JNZ     badDelim                                    ;[2]
+	BIT.B   #PIN_RX, &PRXIN                             ;[4]
+	JNZ     badDelim                                    ;[2]
+	BIT.B   #PIN_RX, &PRXIN                             ;[4]
+	JNZ     badDelim                                    ;[2]
+	BIT.B   #PIN_RX, &PRXIN                             ;[4]
+	JNZ     badDelim                                    ;[2]
+	BIT.B   #PIN_RX, &PRXIN                             ;[4]
+	JNZ     badDelim                                    ;[2]
+	BIT.B   #PIN_RX, &PRXIN                             ;[4]
+	JNZ     badDelim                                    ;[2]
+	BIT.B   #PIN_RX, &PRXIN                             ;[4]
+	JNZ     badDelim                                    ;[2]
+	BIT.B   #PIN_RX, &PRXIN                             ;[4]
+	JNZ     badDelim                                    ;[2]
+	BIT.B   #PIN_RX, &PRXIN                             ;[4]
+	JNZ     badDelim                                    ;[2]
+	BIT.B   #PIN_RX, &PRXIN                             ;[4]
+	JNZ     badDelim                                    ;[2]
+	BIT.B   #PIN_RX, &PRXIN                             ;[4]
+	JNZ     badDelim                                    ;[2]
+	BIT.B   #PIN_RX, &PRXIN                             ;[4]
+	JNZ     badDelim                                    ;[2]
+	BIT.B   #PIN_RX, &PRXIN                             ;[4]
+	JNZ     badDelim                                    ;[2]
+	BIT.B   #PIN_RX, &PRXIN                             ;[4]
+	JNZ     badDelim                                    ;[2]
+	BIT.B   #PIN_RX, &PRXIN                             ;[4]
+	JNZ     badDelim                                    ;[2]
+	BIT.B   #PIN_RX, &PRXIN                             ;[4]
+	JNZ     badDelim                                    ;[2]
+	BIT.B   #PIN_RX, &PRXIN                             ;[4]
+	JNZ     badDelim                                    ;[2]
+	
+	;; ~11.5 us in
+	
+	; Official allowed delimiter range (EPCGlobal Gen2 spec states this should be +/- 5% of 12.5 us, which is 11.875 us - 13.125 us).
+	BIT.B   #PIN_RX, &PRXIN                             ;[4]
+	JNZ     goodDelim                                   ;[2] t = ~11.875 us
+	BIT.B   #PIN_RX, &PRXIN                             ;[4]
+	JNZ     goodDelim                                   ;[2] t = ~12.25 us (Impinj R1000)
+	BIT.B   #PIN_RX, &PRXIN                             ;[4]
+	JNZ     goodDelim                                   ;[2] t = ~12.625 us
+	BIT.B   #PIN_RX, &PRXIN                             ;[4]
+	JNZ     goodDelim                                   ;[2] t = ~13 us
+	BIT.B   #PIN_RX, &PRXIN                             ;[4]
+	JNZ     goodDelim                                   ;[2] t = ~13.375 us
 
-	;@Saman Compatibility with other readers
-	;;;Around 2.7us
-	BIT.B	#PIN_RX,	&PRXIN		;[3]t=3.19..3.43us	(on the src fetch cycle)
-	JNZ		badDelim				;[2]
-	BIT.B	#PIN_RX,	&PRXIN		;[3]t=4.41..4.66us	""
-	JNZ		badDelim				;[2]
-	BIT.B	#PIN_RX,	&PRXIN		;[3]t=5.64..5.88us
-	JNZ		badDelim				;[2]
-
-	BIT.B	#PIN_RX,	&PRXIN		;[3]t=3.19..3.43us	(on the src fetch cycle)
-	JNZ		badDelim				;[2]
-	BIT.B	#PIN_RX,	&PRXIN		;[3]t=4.41..4.66us	""
-	JNZ		badDelim				;[2]
-	BIT.B	#PIN_RX,	&PRXIN		;[3]t=4.41..4.66us	""
-	JNZ		badDelim
-	;Around 8us
-
-	BIT.B	#PIN_RX,	&PRXIN		;[3]t=3.19..3.43us	(on the src fetch cycle)
-	JNZ		badDelim				;[2]
-	BIT.B	#PIN_RX,	&PRXIN		;[3]t=4.41..4.66us	""
-	JNZ		badDelim				;[2]
-	BIT.B	#PIN_RX,	&PRXIN		;[3]t=5.64..5.88us
-	JNZ		badDelim				;[2]
-
-	;@Saman Compatibility with other readers
-	;;;Around 2.7us
-	BIT.B	#PIN_RX,	&PRXIN		;[3]t=3.19..3.43us	(on the src fetch cycle)
-	JNZ		badDelim				;[2]
-	BIT.B	#PIN_RX,	&PRXIN		;[3]t=4.41..4.66us	""
-	JNZ		badDelim				;[2]
-	BIT.B	#PIN_RX,	&PRXIN		;[3]t=5.64..5.88us
-	JNZ		badDelim				;[2]
-
-	BIT.B	#PIN_RX,	&PRXIN		;[3]t=3.19..3.43us	(on the src fetch cycle)
-	JNZ		badDelim				;[2]
-	BIT.B	#PIN_RX,	&PRXIN		;[3]t=4.41..4.66us	""
-	JNZ		badDelim				;[2]
-	BIT.B	#PIN_RX,	&PRXIN		;[3]t=4.41..4.66us	""
-	JNZ		badDelim
-
-	;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-	;*********************************************************************************************************************************
-	; JUST RIGHT (8us < DELIM <16us @ 8MHz)
-	;*********************************************************************************************************************************
-	BIT.B	#PIN_RX,	&PRXIN		;[4]t=6.86-7.11us
-	JNZ		goodDelim				;[2]
-	BIT.B	#PIN_RX,	&PRXIN		;[4]t=8.09-8.33us
-	JNZ		goodDelim				;[2]
-	BIT.B	#PIN_RX,	&PRXIN		;[4]t=9.31-9.56us
-	JNZ		goodDelim				;[2]
-	BIT.B	#PIN_RX,	&PRXIN		;[4]t=10.54-10.78us
-	JNZ		goodDelim				;[2]
-	BIT.B	#PIN_RX,	&PRXIN		;[4]t=6.86-7.11us
-	JNZ		goodDelim
-	BIT.B	#PIN_RX,	&PRXIN		;[4]t=6.86-7.11us
-	JNZ		goodDelim
-	BIT.B	#PIN_RX,	&PRXIN		;[4]t=6.86-7.11us
-	JNZ		goodDelim
-	BIT.B	#PIN_RX,	&PRXIN		;[4]t=6.86-7.11us
-	JNZ		goodDelim
-	BIT.B	#PIN_RX,	&PRXIN		;[4]t=6.86-7.11us
-	JNZ		goodDelim
-	BIT.B	#PIN_RX,	&PRXIN		;[4]t=6.86-7.11us
-	JNZ		goodDelim
-	;;Aroudn 16uS
-
-	BIT.B	#PIN_RX,	&PRXIN		;[4]t=6.86-7.11us
-	JNZ		goodDelim				;[2]
-	BIT.B	#PIN_RX,	&PRXIN		;[4]t=8.09-8.33us
-	JNZ		goodDelim				;[2]
-	BIT.B	#PIN_RX,	&PRXIN		;[4]t=9.31-9.56us
-	JNZ		goodDelim				;[2]
-	BIT.B	#PIN_RX,	&PRXIN		;[4]t=10.54-10.78us
-	JNZ		goodDelim				;[2]
-	BIT.B	#PIN_RX,	&PRXIN		;[4]t=6.86-7.11us
-	JNZ		goodDelim
-	BIT.B	#PIN_RX,	&PRXIN		;[4]t=6.86-7.11us
-	JNZ		goodDelim
-	BIT.B	#PIN_RX,	&PRXIN		;[4]t=6.86-7.11us
-	JNZ		goodDelim
-	BIT.B	#PIN_RX,	&PRXIN		;[4]t=6.86-7.11us
-	JNZ		goodDelim
-	BIT.B	#PIN_RX,	&PRXIN		;[4]t=6.86-7.11us
-	JNZ		goodDelim
-	BIT.B	#PIN_RX,	&PRXIN		;[4]t=6.86-7.11us
-	JNZ		goodDelim
-
-	;*********************************************************************************************************************************
-	; ELSE TOO LONG!! (anything past here was too long)
-	;*********************************************************************************************************************************
-
-badDelim:							; Just Go Back To Sleep...
-	BIT.B	R15, R14
-	BIC		#CCIFG, &TA0CCTL0		;[] clear the interrupt flag for Timer0A0 Compare (safety)
-	CLR		&TA0R					;[] reset TAR value
-	CLR		&(rfid.edge_capture_prev_ccr) ;[] Clear previous value of CCR capture
-	CLR.B		&PRXIFG					;[] clear the Port 1 flag.
+; Delim is too short so go back to sleep.
+badDelim:
+	BIT.B   R15, R14                                    ;[]
+	BIC     #CCIFG, &TA0CCTL0                           ;[] Clear the interrupt flag for Timer0A0 Compare (safety).
+	CLR     &TA0R                                       ;[] Reset TAR value
+	CLR     &(rfid.edge_capture_prev_ccr)               ;[] Clear previous value of CCR capture.
+	CLR.B   &PRXIFG                                     ;[] Clear the Port 1 flag.
 	RETI
 
-	;*********************************************************************************************************************************
-	;Time To March Forward in the RX State Machine																					 *
-	;*********************************************************************************************************************************
-goodDelim:
-;	BIS.W	#(CM_2+CCIE),&TA0CCTL0	;[5] Turn on Timer0A0 -> 4010h -> b14+b4 -> TA0CCTL0 |= CM1+CCIE (CM0-> CAPTURE ON FALLING EDGE,Inverted)
-	; TODO The following shouldn't overwrite other bits in PRXSEL!?
-	; Already interfered with the SPI A1 and MOV changed to BIS.B
-	BIS.B		#PIN_RX,	 &PRXSEL0	;[4] Enable Timer0A0
-	BIC.B		#PIN_RX,	 &PRXSEL1	;[4] Enable Timer0A0
-	CLR.B		&PRXIE					;[4] Disable the Port 1 Interrupt
-	BIC		#(SCG1), 0(SP)		    ;[] Enable the DCO to start counting.
-	PUSHM.A #1,	R15
-	MOV		#FORCE_SKIP_INTO_RTCAL, R15
+; We found a delim ~12.5 us, now turn off PORT1 and prepare Timer0A0.
+goodDelim:                                              ;[24]
+	BIS.B   #PIN_RX, &PRXSEL0                           ;[5] Enable Timer0A0
+	BIC.B   #PIN_RX, &PRXSEL1                           ;[5] Enable Timer0A0
+	CLR.B   &PRXIE                                      ;[4] Disable the Port 1 Interrupt
+	BIC     #(SCG1), 0(SP)                              ;[5] Enable the DCO to start counting
+	BIS.W   #(CM_2+CCIE), &TA0CCTL0                     ;[5] Wake up so we can make use of Timer0A0 control registers?
 
-
-delimDelay:
-	DEC		R15
-	JNZ		delimDelay
-	POPM.A #1,	R15
-
-	; Moved to here because the timer0A0 interrupt should not fire at falling edge of delay cycle which happen after Good Delimiter
-	BIS.W	#(CM_2+CCIE),&TA0CCTL0
-startupT0A0_ISR:
-	BIC		#CCIFG, &TA0CCTL0		;[] clear the interrupt flag for Timer0A0 Compare
-	CLR		&TA0R					;[] reset TAR value
-	CLR		&(rfid.edge_capture_prev_ccr) ;[] Clear previous value of CCR capture
-	CLR		&(rfid.edge_capture_prev_ccr) ;[] reset previous edge capture time
-	CLR.B	&PRXIFG					;[5] clear the Port 1 flag.
-	ADD 	#36, &TA0R				;The modified code seem to add some commands that increase the amount of waiting after finding the Good Delimiter.
-	;We just need to wait for 1 Tari (in this case 12.5us) which is equal to 50 cycles for 4MHz before counting the length of RTcal but instead in this code we wait for about
-	;86 cycles and after that clear the TA0R. This is the reason we added #36 to TA0R.
-
-	RETI
-
-	;	//Now wait into data0 somewhere!
+startupT0A0_ISR:                                        ;[22]
+	BIC     #CCIFG, &TA0CCTL0                           ;[5] Clear the interrupt flag for Timer0A0 Compare
+	CLR     &TA0R                                       ;[4] ***Reset clock!***
+	CLR     &(rfid.edge_capture_prev_ccr)               ;[4] Clear previous value of CCR capture
+	CLR.B   &PRXIFG                                     ;[4] Clear the Port 1 flag.
+	
+	RETI                                                ;[5] Return from interrupt (46 cycles total).
 
 ;*************************************************************************************************************************************
-; DEFINE THE INTERRUPT VECTOR ASSIGNMENT																							 *
+; DEFINE THE INTERRUPT VECTOR ASSIGNMENT
 ;*************************************************************************************************************************************
-	;.sect ".int36"					; Port 1 Vector
-	;.short  RX_ISR					; This sect/short pair sets int02 = RX_ISR addr.
+	;.sect ".int36"                                     ; Port 1 Vector
+	;.short  RX_ISR                                     ; This sect/short pair sets int02 = RX_ISR addr.
 	.end

--- a/CCS/wisp-base/RFID/Timer0A0_ISR.asm
+++ b/CCS/wisp-base/RFID/Timer0A0_ISR.asm
@@ -1,15 +1,14 @@
 ;/***********************************************************************************************************************************/
-;/**@file		Timer0A0_ISR.asm
-;* 	@brief		Receive chain decoding routines.
-;* 	@details
+;/**@file       Timer0A0_ISR.asm
+;*  @brief      Implement the receiving mechanism of RFID (RTCAL, TRCAL, data bits).
 ;*
-;* 	@author		Justin Reina, UW Sensor Systems Lab
-;* 	@created
-;* 	@last rev	
+;*  @author     Justin Reina, UW Sensor Systems Lab
+;*  @created
+;*  @last rev
 ;*
-;* 	@notes
+;*  @notes
 ;*
-;*	@todo
+;*	@TODO
 ;*/
 ;/***********************************************************************************************************************************/
 
@@ -19,158 +18,155 @@
 	.retainrefs
 
 ;Register Defs
-R_dest			.set  R4
-R_bits			.set  R5
-R_bitCt			.set  R6
-R_newCt			.set  R7
-R_pivot			.set  R8
-R_scratch2		.set  R9
-R_wakeupBits	.set  R10
-R_scratch0  	.set  R15
+R_dest          .set  R4
+R_bits          .set  R5
+R_bitCt         .set  R6
+R_newCt         .set  R7
+R_pivot         .set  R8
+R_scratch2      .set  R9
+R_wakeupBits    .set  R10
+R_scratch0      .set  R15
 
 
 ;*************************************************************************************************************************************
-;	Timer0A0 ISR: On Entry Latch,Reset T0A0R. Then Parse and Deploy Mode
+;   Timer0A0 ISR: Save timer values on entry, then parse and deploy mode accordingly.
 ;*************************************************************************************************************************************
-Timer0A0_ISR:						;[6] entry cycles into an interrupt (well, 5-6)
+Timer0A0_ISR:                                                ;[6]
 
-	 MOV		&TA0CCR0, 	R_newCt	;[3] latch TA0CCR1 value into the new count reg
-	 SUB		&(rfid.edge_capture_prev_ccr), R_newCt; Compute delta by subtracting CCR value captured on previous edge
-	 MOV		&TA0CCR0, 	&(rfid.edge_capture_prev_ccr); Update previous CCR value with current value (preparing for next edge)
-
-     BIC		#CCIFG, 	&TA0CCTL0;[4] clear the TA1 interrupt flag
+	MOV     &TA0CCR0, R_newCt                                ;[3] Store the timer value where the falling edge was detected.
+	SUB     &(rfid.edge_capture_prev_ccr), R_newCt           ;[]  delta = new_edge - prev_edge
+	MOV     &TA0CCR0, &(rfid.edge_capture_prev_ccr)          ;[]  prev_edge = new_edge
 	
-;Check Which Mode We Are In
-	CMP		#(2),		R_bits		;[2]
-	JGE		ModeD_process			;[2] deploy mode D (does a signed comparison)
-	CMP		#(1),		R_bits		;[2]
-	JEQ		ModeC_process			;[2] deploy mode C
-	CMP		#(0),		R_bits		;[2]
-	JEQ 	ModeB_process			;[2] deploy mode B
-									;[0] else deploy mode A
+	BIC     #CCIFG, &TA0CCTL0                                ;[4] Clear interrupt flag so the timer can continue.
+	
+	; Check how many bits we have received.
+	CMP     #(2), R_bits                                     ;[2]
+	JGE     ModeD_process                                    ;[2] R_bits = 2  -> rest of data bits
+	CMP     #(1), R_bits                                     ;[2]
+	JEQ     ModeC_process                                    ;[2] R_bits = 1  -> 2nd data bit
+	CMP     #(0), R_bits                                     ;[2]
+	JEQ     ModeB_process                                    ;[2] R_bits = 0  -> TRCAL and/or 1st data bit
+	CMP     #(-1), R_bits                                    ;[2] R_bits = -1 -> RTCAL
+	JEQ     ModeA_process                                    ;[2]
+	
+	INC     R_bits                                           ;[0] Else, we detected the falling edge of data-0 after the delimiter.
+	RETI                                                     ;[5] Return from interrupt.
 
 ;*************************************************************************************************************************************
-;	MODE A: RTCal
+;   MODE A: RTCal
 ;*************************************************************************************************************************************
 ModeA_process:
-; DEBUG!!
-	CMP		#RTCAL_MIN,  R_newCt 	;[2]error catch: check if valid RTCal (i.e. if TA0CCR1<2TARI)
-	JL		failed_RTCal		 	;[2] break if doesn't work.
-    CMP		#RTCAL_MAX,	 R_newCt 	;[2]
-    JGE		failed_RTCal		 	;[2] break if doesn't work.
-
-	;ok valid RTCal, now process to get pivot(R8)
-    MOV    	R_newCt, 	 R_scratch2 ;[1] Load R7 into a scratch reg(R9) so we can use this RTCal value in Mode 2 Processing next
-    ADD		#RTCAL_OFFS, R_newCt 	;[2] Compensate for lost cycles in this measurement method to get to actual RTCal val.
-    RRA   	R_newCt             	;[1] Divide R7 by 2
-    MOV    	#(-1),		 R_pivot    ;[1] preload pivot value with MAX (i.e. 0xFFFFh)
-    SUB    	R_newCt, 	 R_pivot  	;[1] pivotReg = pivotReg-(currCount/2) <-- This sets up the pivot reg for calc discussed.
-    INC    	R_bits               	;[1] (r5=2) use r5 as a flag for the next entry (entry into mode 2)
-    RETI                        	;[5] return from interrupt
+	CMP     #RTCAL_MIN, R_newCt                              ;[2] RTCAL >= 2.5*TARI - PW?
+	JL      failed_RTCal                                     ;[2] RTCAL  too small
+	CMP     #RTCAL_MAX, R_newCt                              ;[2] RTCAL <= 3*TARI - PW?
+	JGE     failed_RTCal                                     ;[2] RTCAL too large
+	
+	;RTCAL is correct length, now proceed to compute pivot.
+	MOV     R_newCt, R_scratch2                              ;[1] Save RTCAL to compare with TRCAL later on.
+	RRA     R_newCt                                          ;[1] pivot = RTCAL/2
+	MOV     #(-1), R_pivot                                   ;[1] Preload pivot value with MAX (i.e. 0xFFFFh)
+	SUB     R_newCt, R_pivot                                 ;[1] Make pivot negative (so we can use ADD later on).
+	INC     R_bits                                           ;[1] RTCAL done, proceed to read TRCAL and/or 1st data bit.
+	RETI                                                     ;[5] Return
 
 
 ;*************************************************************************************************************************************
 ;	MODE B: TRCal/bit0
 ;*************************************************************************************************************************************
 ModeB_process:
-	CMP    	R_scratch2, R_newCt		;[1] is currCount>RTCal? if so it's TRCal, else data
-    JGE    	ModeB_TRCal        		;[2] if currCount>RTCal then jump to process TRCal
-
-
-	;else it's databit0. store it!
+	CMP     R_scratch2, R_newCt                              ;[1] delta >= RTCAL -> TRCAL, else 1st data bit.
+	JGE     ModeB_TRCal                                      ;[2]
+	NOP                                                      ;[]  Pipeline dodging. TODO: Is this needed?
+	NOP
+	NOP
+	
 ModeB_dataBit:
-    ADD    	R_pivot, 	R_newCt    	;[1] do pivotTest (currCount = currCount+pivotReg. if Carry, its data1) <-note: thus dataBit is stored in carry.
-    ADDC.B 	@R_dest+,	-1(R_dest) 	;[5] shift cmd[curr] by one (i.e. add it to itself), then store dataBit(carryFlag), into cmd[currCmdByte], then increment currCmdByte (all as one asm:))
+	ADD     R_pivot, R_newCt                                 ;[1] -pivot + delta > FFFF will result in carry bit.
+	ADDC.B  @R_dest+,-1(R_dest)                              ;[5] Add R_dest to itself, i.e. multiply by 2, i.e. shift 1 bit left. Then add carry from previous operation.
+	INC     R_bits                                           ;[1] Increment bit received count.
+	INC     R_bitCt                                          ;[1] Increment current command bit received count.
+	DEC     R_dest                                           ;[]
+	RETI                                                     ;[5] Return
 
-    INC    	R_bits                  ;[1] update R5(bits) cause we got a databit
-    INC    	R_bitCt                 ;[1] mark that we've stored a bit into r6(currCmdBits)
-    DEC		R_dest
-    RETI                        	;[5] return from interrupt
-
-
-    ;Check if Valid TRCal (i.e. ~50.2us).
 ModeB_TRCal:
-    ;BIS.B	#PIN_DBG0, &PDBGOUT      ;@us_change: cancell debug line here
-    ;BIC.B	#PIN_DBG0, &PDBGOUT
-    CMP		#TRCAL_MIN, R_newCt		;[2]
-    JL		failed_TRCal 			;[2] reset RX State Machine if TRCal is too short!! we won't check if too long, because 320kHz uses the max TRCal length.
-    CMP		#TRCAL_MAX,  R_newCt 	;[2] error catch: check if valid TRCal (i.e. if TA0CCR1>2TARI)
-	JGE		failed_TRCal			;[2]
-
-    CLR    	R_bitCt					;[1] start the counting of R6 fresh (cause databits will come immeadiately following)
-    RETI                        	;[5] return from interrupt
+	CMP     #TRCAL_MIN, R_newCt                              ;[2] TRCAL >= 1.1*RTCAL_ESTIMATE?
+	JL      failed_TRCal                                     ;[2] TRCAL too small
+	CMP     #TRCAL_MAX,  R_newCt                             ;[2] TRCAL <= 3 RTCAL_ESTIMATE?
+	JGE     failed_TRCal                                     ;[2] TRCAL too large
+	
+	CLR     R_bitCt                                          ;[1] Since we received full preamble, clear current command bit received count.
+	RETI                                                     ;[5] Return
 
 
 ;*************************************************************************************************************************************
-;	MODE C: bit1
+;   MODE C: bit1
 ;*************************************************************************************************************************************
 ModeC_process:
-    ADD    	R_pivot, 	R_newCt    	;[1] do pivotTest (currCount = currCount+pivotReg. if Carry, its data1) <-note: thus dataBit is stored in carry.
-    ADDC.B 	@R_dest+,	-1(R_dest) 	;[5] shift cmd[curr] by one (i.e. add it to itself), then store dataBit(carryFlag), into cmd[currCmdByte], then increment currCmdByte (all as one asm:))
-	;Check if Query Rep
-	MOV.B	(cmd),		R_scratch0	;[2] pull in the first two dataBits (b1b0)
-	AND.B	#0x03,		R_scratch0	;[2] mask out everything but b1b0
-    CMP.B	#0x00,		R_scratch0	;[1] check if we got a queryRep
-	JEQ		ModeC_queryRep			;[2]
-
-    INC    	R_bits               	;[1] update R5(bits) cause we got a databit
-    INC    	R_bitCt                 ;[1] mark that we've stored a bit into r6(currCmdBits)
-    DEC		R_dest
-	RETI                        	;[5] return from interrupt
-
-
+	ADD     R_pivot, R_newCt                                 ;[1] -pivot + delta > FFFF will result in carry bit.
+	ADDC.B  @R_dest+, -1(R_dest)                             ;[5] Add R_dest to itself, i.e. multiply by 2, i.e. shift 1 bit left. Then add carry from previous operation.
+	
+	; We have now received 2 bits, check if it's the QueryRep command. (6.3.2.12.2.3)
+	MOV.B   (cmd), R_scratch0                                ;[2] Pull cmd_buffer (b1b0)
+	AND.B   #0x03, R_scratch0                                ;[2] Mask out everything but b1b0 (i.e. use only first 2 bits)
+	CMP.B   #0x00, R_scratch0                                ;[1] Compare command with "00"
+	JEQ     ModeC_queryRep                                   ;[2]
+	
+	; If we did get a queryRep, we don't need to do these operations (because WISP is ignoring session field anyway).
+	INC     R_bits                                           ;[1] update R5(bits) cause we got a databit
+	INC     R_bitCt                                          ;[1] mark that we've stored a bit into r6(currCmdBits)
+	DEC     R_dest
+	RETI                                                     ;[5] return from interrupt
+	
 ModeC_queryRep:
-	MOV.W	#(0), 		&TA0CTL				;[4] turn off the timer
-	MOV.B	#CMD_PARSE_AS_QUERY_REP, &cmd	;[4] set the cmd[0] to a known value for queryRep to parse.
-    BIC.W	#(SCG1+CPUOFF+OSCOFF), SR_SP_OFF(SP);[5] Turn off interrupts, enable clock!
-    RETI                        			;[5] return from interrupt
+	MOV.W   #(0), &TA0CTL                                    ;[4] turn off the timer
+	MOV.B   #CMD_PARSE_AS_QUERY_REP, &cmd                    ;[4] set the cmd[0] to a known value for queryRep to parse.
+	BIC.W   #(SCG1+CPUOFF+OSCOFF), SR_SP_OFF(SP)             ;[5] Turn off interrupts, enable clock!
+	RETI                                                     ;[5] return from interrupt
 
 
 ;*************************************************************************************************************************************
 ;	MODE D: Plain ol' Data Bit (bits>=2)
 ;*************************************************************************************************************************************
 ModeD_process:
-    ADD    	R_pivot, 	R_newCt    	;[1] do pivotTest (currCount = currCount+pivotReg. if Carry, its data1) <-note: thus dataBit is stored in carry.
-    ADDC.B 	@R_dest+,	-1(R_dest) 	;[5] shift cmd[curr] by one (i.e. add it to itself), then store dataBit(carryFlag), into cmd[currCmdByte], then increment currCmdByte (all as one asm:))
-
-    INC    	R_bits                  ;[1] update R5(bits) cause we got a databit
-    INC    	R_bitCt                 ;[1] mark that we've stored a bit into r6(currCmdBits)
-
-	;Check if that finished off a whole byte in cmd[]
-	CMP.W		#(8),		R_bitCt	;[1] Check if we have gotten 8 bits
-	JGE		ModeD_setupNewByte		;[2]
-	DEC		R_dest
-    RETI                        	;[5] return from interrupt
+	ADD     R_pivot, R_newCt                                 ;[1] -pivot + delta > FFFF will result in carry bit.
+	ADDC.B  @R_dest+, -1(R_dest)                             ;[5] Add R_dest to itself, i.e. multiply by 2, i.e. shift 1 bit left. Then add carry from previous operation.
+	
+	INC     R_bits                                           ;[1] update R5(bits) cause we got a databit
+	INC     R_bitCt                                          ;[1] mark that we've stored a bit into r6(currCmdBits)
+	
+	; Check if byte is finished in cmd.
+	CMP.W   #(8), R_bitCt                                    ;[1]
+	JGE     ModeD_setupNewByte                               ;[2]
+	DEC     R_dest
+	RETI                                                     ;[5] return from interrupt
 
 
 ModeD_setupNewByte:
-	CLR		R_bitCt					;[1] Clear the Current Bit Count to reset for the next byte
-	BIC		#(SCG1+CPUOFF+OSCOFF),	SR_SP_OFF(SP);[5] enable the clock so the doRFIDThread can parse b7-b4! *Leave Interrupts On.
-    RETI                        	;[5] return from interrupt
+	CLR     R_bitCt                                          ;[1] Clear bit count for next byte in cmd buffer.
+	BIC     #(SCG1+CPUOFF+OSCOFF), SR_SP_OFF(SP)             ;[5] enable the clock so the doRFIDThread can parse b7-b4! *Leave Interrupts On.
+	RETI                                                     ;[5] return from interrupt
 
 
 ;*************************************************************************************************************************************
-;	MODE FAILS: Reset RX State Machine																								 *
+;   MODE FAILS: Reset RX State Machine
 ;*************************************************************************************************************************************
 failed_RTCal:
 failed_TRCal:
-	CLR 	R_bits					;[1] reset R5 for rentry into RX State Machine
-	CLR		R_bitCt					;[]
-	BIS.B	#PIN_RX, &PRXIES		;[4] wait again for #1 to fire on falling edge
-	MOV.B	#PIN_RX, &PRXIE			; Enable the interrupt
-	CLR.B	&PRXIFG					;[] clr any pending flasgs (safety)
+	CLR     R_bits                                           ;[1] reset R5 for rentry into RX State Machine
+	CLR     R_bitCt                                          ;[]
+	BIS.B   #PIN_RX, &PRXIES                                 ;[4] wait again for #1 to fire on falling edge
+	MOV.B   #PIN_RX, &PRXIE                                  ; Enable the interrupt
+	CLR.B   &PRXIFG                                          ;[] clr any pending flags (safety)
 	; TODO The following shouldn't overwrite other bits in PRXSEL!?
-	BIC.B	#PIN_RX, &PRXSEL0				;[] disable TimerA1
-	BIC.B	#PIN_RX, &PRXSEL1				;[] disable TimerA1
-	BIC.W  	#4010h, TA0CCTL0     	;[5] Turn off TimerA1 -> 4010h -> b14+b4 -> TA0CCTL1 &= ~CM0+CCIE (CM0-> CAPTURE ON RISING EDGE)
-
-	; /** @todo Figure out why the following line gives us trouble. What state do/should we return to here? */
-	;BIS		#(LPM4+GIE), SR_SP_OFF(SP);[5] put tag back into LPM4, set GIE
-    RETI                        	;[5] return from interrupt
+	BIC.B   #PIN_RX, &PRXSEL0                                ;[] disable TimerA1
+	BIC.B   #PIN_RX, &PRXSEL1                                ;[] disable TimerA1
+	BIC.W   #4010h, TA0CCTL0                                 ;[5] Turn off TimerA1 -> 4010h -> b14+b4 -> TA0CCTL1 &= ~CM0+CCIE (CM0-> CAPTURE ON RISING EDGE)
+	
+	RETI                                                     ;[5] return from interrupt
 
 ;*************************************************************************************************************************************
-; DEFINE THE INTERRUPT VECTOR ASSIGNMENT																							 *
+;   DEFINE THE INTERRUPT VECTOR ASSIGNMENT
 ;*************************************************************************************************************************************
-	;.sect	".int45"			    ; Timer0_A0 Vector
-	;.short  Timer0A0_ISR			; This sect/short pair sets int53 = Timer0A0_ISR addr.
+	;.sect	".int45"                                         ; Timer0_A0 Vector
+	;.short  Timer0A0_ISR                                    ; This sect/short pair sets int53 = Timer0A0_ISR addr.
 	.end

--- a/CCS/wisp-base/RFID/Timer0A1_ISR.asm
+++ b/CCS/wisp-base/RFID/Timer0A1_ISR.asm
@@ -52,12 +52,7 @@ CPU_is_off:		;[]i.e. we're still in latch mode. restart the RX State Machine. Tw
 
 	BIC.B	#(CM_2+CCIE), &TA0CCTL0	;[] disable capture and interrupts by capture-compare unit
 	BIC		#(CCIFG),	TA0CCTL0	;[] clear the interrupt flag
-
-	NOP
-	BIC		#(SMCLKREQEN+MCLKREQEN+ACLKREQEN), CSCTL6	;[] disable all clk requests, they prevent LPM4
-	NOP
-	BIS		#(SCG0+SCG1+OSCOFF+CPUOFF+GIE), SR			;[] put tag back into LPM4
-	NOP
+	BIS		#(SCG1+OSCOFF+CPUOFF+GIE), SR_SP_OFF(SP);[] put tag back into LPM4
 
 	POPM.A #1, R15
 	RETI							;[5] return from interrupt
@@ -72,10 +67,7 @@ Wakeup_Proc:
 	
 	MOV		#(FALSE), &isDoingLowPwrSleep ;[] clear that flag!
 
-	NOP
-	BIC		#(SCG0+SCG1+OSCOFF+CPUOFF+GIE), SR;[] take tag out of LPM4
-	NOP
-
+	BIC		#(SCG1+OSCOFF+CPUOFF+GIE), SR_SP_OFF(SP);[] take tag out of LPM4
 	POPM.A #1, R15
 	RETI							;[5] return from interrupt
 

--- a/CCS/wisp-base/RFID/WISP_doRFID.asm
+++ b/CCS/wisp-base/RFID/WISP_doRFID.asm
@@ -229,7 +229,7 @@ callBlockWriteHandler:
 	BIT.B	#MODE_WRITE, &(rfid.mode)
 	JNC		endDoRFID
 	CALLA	#handleBlockWrite
-	JMP		endDoRFID
+	JMP		WISP_doRFID
 
 
 ;/************************************************************************************************************************************/

--- a/CCS/wisp-base/RFID/WISP_doRFID.asm
+++ b/CCS/wisp-base/RFID/WISP_doRFID.asm
@@ -115,9 +115,6 @@ keepDoingRFID:
 	MOV.B	#PIN_RX,	&PRXIE		;[] Enable Port1 interrupt
 
 	; @todo Shouldn't we sleep_till_full_power here? Where else could that happen?
-	NOP
-	BIC		#(SMCLKREQEN+MCLKREQEN+ACLKREQEN), CSCTL6	;[] disable all clk requests, they prevent LPM4
-	NOP
 	BIS		#(GIE+SCG1+SCG0+OSCOFF+CPUOFF), SR			;[] sleep! (LPM4 | GIE)
 	NOP
 

--- a/CCS/wisp-base/RFID/rfid.h
+++ b/CCS/wisp-base/RFID/rfid.h
@@ -27,7 +27,7 @@
 typedef struct {
 	uint8_t* epcBuf;
 	uint16_t* writeBufPtr;
-	uint8_t* blockWriteBufPtr;
+	uint16_t* blockWriteBufPtr;
 	uint16_t* blockWriteSizePtr;
 	uint8_t* readBufPtr;
 } WISP_dataStructInterface_t;

--- a/CCS/wisp-base/RFID/rfid_BlockWriteHandle.asm
+++ b/CCS/wisp-base/RFID/rfid_BlockWriteHandle.asm
@@ -2,7 +2,7 @@
 ;*	@brief
 ;* 	@details
 ;*
-;*	@author		Aaron Parks, Justin Reina, UW Sensor Systems Lab
+;*	@author		Jethro Tan, Aaron Parks, Justin Reina, UW Sensor Systems Lab
 ;*	@created
 ;*	@last rev
 ;*
@@ -10,254 +10,217 @@
 ;*				BLOCKWRITE: {CMD [8], MEMBANK [2], WordPtr [6?], WordCount [8], Data [VAR], RN [16], CRC [16]}
 ;*
 ;*	@section
-;*
-;*	@todo		Show the blockwrite command bitfields here
-;*  @todo		Add CRC check for R=>T command, even if it needs to be after-the-fact
-;*  @todo		Figure out why using R12 doesn't work here...
 ;*/
 
-   .cdecls C,LIST, "../globals.h"
-   .cdecls C,LIST, "rfid.h"
+	.cdecls C,LIST, "../globals.h"
+	.cdecls C,LIST, "rfid.h"
 
-R_byteCount	.set  R12				;[0] Number of words in payload
+R_bits      .set  R5
 R_scratch2	.set  R13
 R_scratch1	.set  R14
 R_scratch0	.set  R15
 
-   	.ref cmd
+	.ref cmd
 	.def  handleBlockWrite
 	.global RxClock, TxClock
 	.sect ".text"
 
-;	extern void handleBlockWrite (uint8_t handle);
 handleBlockWrite:
 
-	;/------------------------------------------------------------------------/
-	; Wait for first 4 bytes
-	;/------------------------------------------------------------------------/
-
+;Wait for first two bytes to come in. then memBank is in cmd[1].b7b6
 waitOnBits_0:
-	CMP #32, R5; bit count is always in R5
-	JLO waitOnBits_0
+	CMP     #16, R_bits                                     ;[2] Proceed when R_bits > 16 (ceil 8+2 -> 16)
+	JLO     waitOnBits_0                                    ;[2]
 
-	;Now CMD[0]~CMD[3] should contain: {CMD_ID, (MEMBANK | WP), (WP | WC), (WC | DATA[0])}
+calc_memBank:
+	MOV.B	(cmd+1), R_scratch0                             ;[3] load cmd byte 2 into R_scratch0. memBank is in b7b6 (0xC0)
+	AND.B	#0xC0, R_scratch0                               ;[2] mask of non-memBank bits, then switch on it to load corr memBankPtr
+	RRA		R_scratch0                                      ;[1] move b7b6 down to b1b0
+	RRA		R_scratch0                                      ;[1] move b7b6 down to b1b0
+	RRA		R_scratch0                                      ;[1] move b7b6 down to b1b0
+	RRA		R_scratch0                                      ;[1] move b7b6 down to b1b0
+	RRA		R_scratch0                                      ;[1] move b7b6 down to b1b0
+	RRA		R_scratch0                                      ;[1] move b7b6 down to b1b0
+	MOV.B   R_scratch0, &(RWData.memBank)                   ;[3] store the memBank
 
-	;/------------------------------------------------------------------------/
-	; Extract word count and store in a CPU register
-	;/------------------------------------------------------------------------/
-
-	; Extract word count from CMD[2]~CMD[3]. Store as a byte count for convenience.
-	CLR.W R_scratch0
-	MOV.B &(cmd+3), R_scratch0;
-	CLR.W R_byteCount;
-	MOV.B &(cmd+2), R_byteCount;
-	RLC.B R_scratch0;
-	RLC.B R_byteCount;
-	RLC.B R_scratch0;
-	RLC.B R_byteCount; Now R_byteCount = wordCount
-	BIC #(0xFF00), R_byteCount; To make sure top byte is zeroed
-	RLA R_byteCount; Now R_byteCount = wordCount*2
-
-	;R_byteCount now contains (word count)*2
-	;Validate BC - set limit based on buffer size
-	MOV #CMDBUFF_SIZE, R_scratch0;
-	SUB #8, R_scratch0;
-	CMP R_byteCount, R_scratch0;
-	JGE skipByteCountCap; If R_scratch0 >= R_byteCount, we’ve got enough space and don’t have to adjust byteCount.
-	MOV R_scratch0, R_byteCount;
-skipByteCountCap:
-
-	;Todo: Should probably fail here if byteCount is too large to handle, instead of simply capping byteCount.
-
-	;/------------------------------------------------------------------------/
-	; Wait for byte number BC+8 (CMD[BC+7])
-	;/------------------------------------------------------------------------/
-
-	MOV R_byteCount, R_scratch0;
-	ADD #8, R_scratch0;
-	RLA R_scratch0; Multiply by 8
-	RLA R_scratch0;
-	RLA R_scratch0;
-	
+; Now wait until we have all bits to extract the WordPtr.
 waitOnBits_1:
-	CMP R_scratch0, R5;
-	JLO waitOnBits_1; while(R5<R_scratch0)
+	CMP.W   #24, R_bits                                     ;[2] Wait until first 3 bytes are fully received.
+	JLO     waitOnBits_1                                    ;[2]
 
-	;Now CMD[BC+7] has arrived
-	;/------------------------------------------------------------------------/
-	; Future work: Check CRC over entire CMD buffer now, and include result of check in response to reader.
-	;/------------------------------------------------------------------------/
+; Extract WordPtr.
+calc_wordPtr:
+	MOV.B 	(cmd+1), R_scratch0                             ;[3] bring in top 6 bits into b5-b0 of R_scratch0 (wordCt.b7-b2)
+	MOV.B 	(cmd+2), R_scratch1                             ;[3] bring in bot 2 bits into b7b6  of R_scratch1 (wordCt.b1-b0)
+	RLC.B	R_scratch1                                      ;[1] pull out b7 from R_scratch1 (wordCt.b1)
+	RLC.B	R_scratch0                                      ;[1] shove it into R_scratch0 at bottom (wordCt.b1)
+	RLC.B	R_scratch1                                      ;[1] pull out b7 from R_scratch1 (wordCt.b0)
+	RLC.B	R_scratch0                                      ;[1] shove it into R_scratch0 at bottom (wordCt.b0)
+	MOV.B	R_scratch0, R_scratch0                          ;[1] mask wordPtr to just lower 8 bits
+	MOV.B	R_scratch0, &(RWData.wordPtr)                   ;[3] store the wordPtr
 
-	;/------------------------------------------------------------------------/
-	; Respond to reader
-	;/------------------------------------------------------------------------/
 
-	; Housekeeping: Save needed CPU registers in preparation for CRC16 call
-	PUSHM.A #1, R_byteCount;
+; Impinj hasn't implemented BlockWrite corrctly... it's more of a BulkWrite using BlockWrite rather than a real BlockWrite.
+; Instead of using the WordCount to send multiple words, it uses an offset using the WordPtr.
 
-	;Load the Reply Buffer (rfidBuf)
-	;Load up function call, then transmit! bam!
-	MOV (rfid.handle), R_scratch0;[3] bring in the RN16
-	SWPB	R_scratch0 ;[1] swap bytes so we can shove full word out in one call (MSByte into dataBuf[0],...)
-	MOV R_scratch0, &(rfidBuf) ;[4] load the MSByte
+;; Wait until we have all bits to extract WordCount.
+;waitOnBits_2:
+;	CMP.W   #32, R_bits                                     ;[2] Wait until first 4 bytes are fully received.
+;	JLO     waitOnBits_2                                    ;[2]
+;
+;calc_wordCnt:
+;	MOV.B   (cmd+2), R_scratch0                             ;[3] bring in top 6 bits into b5-b0 of R_scratch0 (wordCt.b7-b2)
+;	MOV.B   (cmd+3), R_scratch1                             ;[3] bring in bot 2 bits into b7b6  of R_scratch1 (wordCt.b1-b0)
+;	RLC.B   R_scratch1                                      ;[1] pull out b7 from R_scratch1 (wordCt.b1)
+;	RLC.B   R_scratch0                                      ;[1] shove it into R_scratch0 at bottom (wordCt.b1)
+;	RLC.B   R_scratch1                                      ;[1] pull out b7 from R_scratch1 (wordCt.b0)
+;	RLC.B   R_scratch0                                      ;[1] shove it into R_scratch0 at bottom (wordCt.b0)
+;	MOV.B   R_scratch0, R_scratch0                          ;[1] mask wordPtr to just lower 8 bits
+;	MOV.B  R_scratch0, &(RWData.wrData)                     ;[3] store the wordCnt
 
-	;Calc CRC16! (careful, it will clobber R11-R15)
-	;uint16_t crc16_ccitt(uint16_t preload,uint8_t *dataPtr, uint16_t numBytes);
-	MOV #(rfidBuf), R13 ;[2] load &dataBuf[0] as dataPtr
-	MOV #(2), R14 ;[2] load num of bytes in ACK
-	MOV #ZERO_BIT_CRC, R12 ;[1]
-	CALLA	#crc16_ccitt ;[5+196]
 
-	;On return: R12 holds the CRC16 value.
-	;STORE CRC16
-	MOV.B	R12, &(rfidBuf+3) ;[4] store lower CRC byte first
-	SWPB	R12 ;[1] move upper byte into lower byte
-	MOV.B	R12, &(rfidBuf+2) ;[4] store upper CRC byte
+; Wait for data to write.
+waitOnBits_3:
+	CMP.W   #48, R_bits                                     ;[2] Wait until first 6 bytes are fully received.
+	JLO     waitOnBits_3                                    ;[2]
 
-	CLRC
-	RRC.B	(rfidBuf)
-	RRC.B	(rfidBuf+1)
-	RRC.B	(rfidBuf+2)
-	RRC.B	(rfidBuf+3)
-	RRC.B	(rfidBuf+4)
+store_Word:
+	MOV.B   (cmd+3), R_scratch1                             ;[3] bring in top 6 bits into b5-b0 of R_scratch1 (data.b15-b10)
+	MOV.B   (cmd+4), R_scratch2                             ;[3] bring in mid 8 bits into b7-b0 of R_scratch2 (data.b9-b2)
+	MOV.B   (cmd+5), R12                                    ;[3] bring in bot 2 bits into b7b6  of R12 (data.b1b0)
 
-	;Set up to transmit reply
-haltRxSM_inWriteHandle:
+	RLC.B   R_scratch2                                      ;[1]
+	RLC.B   R_scratch1                                      ;[1]
+	RLC.B   R_scratch2                                      ;[1]
+	RLC.B   R_scratch1                                      ;[1]
+	RRC.B   R_scratch2                                      ;[1]
+	RRC.B   R_scratch2                                      ;[1]
 
-	;this should be the equivalent of the RxSM call in C Code. WARNING: if RxSM() ever changes, change it here too!!!!
-	DINT;[2]
-	NOP
-	CLR		&TA0CTL					;[4]
+	RLC.B   R12                                             ;[1]
+	RLC.B   R_scratch2                                      ;[1]
+	RLC.B   R12                                             ;[1]
+	RLC.B   R_scratch2                                      ;[1]
 
-	;Transmit timing delay
-	MOV #TX_TIMING_WRITE, R_scratch0 ;[1]
-	MOV #2000, R_scratch0;DEBUG!!!!!!!!!
+	SWPB    R_scratch1                                      ;[1]
+	BIS     R_scratch2, R_scratch1                          ;[1] merge b15-b8(R_scratch1) and b7-b(R_scratch2) together into R_scratch1
 
-timing_delay_for_Write:
-	DEC R_scratch0; [1] while((X--)>0);
-	CMP #0XFFFF, R_scratch0 ;[1] 'when X underflows'
-	JNE timing_delay_for_Write ;[2]
+	MOV.B   &(RWData.wordPtr), R_scratch2                   ;[3] Put offset to R15
+	RLAM.A  #1, R_scratch2                                  ;[2] Offset *= 2
+	ADDX.A  &(RWData.bwrBufPtr), R_scratch2                 ;[3] Add base address to offset.
+	MOV     R_scratch1, 0(R_scratch2)                       ;[3] move the data out to the correct address.
 
-	;TRANSMIT (16pre,38tillTxinTxFM0 -> 54cycles)
-	MOV #rfidBuf, 	R12 ;[2] load the &rfidBuf[0]
-	MOV #(4), R13 ;[1] load into corr reg (numBytes)
-	MOV #1, R14	;[1] load numBits=1
-	MOV.B	#TREXT_ON,	R15 ;[3] load TRext (write always uses trext=1. wtf)
+; Wait on handle.
+waitOnBits_4:
+	CMP.W   #64, R_bits                                     ;[2]
+	JLO     waitOnBits_4                                    ;[2]
 
-	CALLA	#TxFM0 ;[5] call the routine
+; Pull handle into R_scratch1.
+	MOV.B   (cmd+5), R_scratch1                             ;[3] bring in top 6 bits into b5-b0 of R_scratch1 (data.b15-b10)
+	MOV.B   (cmd+6), R_scratch2                             ;[3] bring in mid 8 bits into b7-b0 of R_scratch2 (data.b9-b2)
+	MOV.B   (cmd+7), R12                                    ;[3] bring in bot 2 bits into b7b6  of R12 (data.b1b0)
+	
+	RLC.B   R_scratch2                                      ;[1]
+	RLC.B   R_scratch1                                      ;[1]
+	RLC.B   R_scratch2                                      ;[1]
+	RLC.B   R_scratch1                                      ;[1]
+	RRC.B   R_scratch2                                      ;[1]
+	RRC.B   R_scratch2                                      ;[1]
+	
+	RLC.B   R12                                             ;[1]
+	RLC.B   R_scratch2                                      ;[1]
+	RLC.B   R12                                             ;[1]
+	RLC.B   R_scratch2                                      ;[1]
+	
+	SWPB    R_scratch1                                      ;[1]
+	BIS     R_scratch2, R_scratch1                          ;[1] merge b15-b8(R_scratch1) and b7-b(R_scratch2) together into R_scratch1
 
-	;TxFM0(volatile uint8_t *data,uint8_t numBytes,uint8_t numBits,uint8_t TRext);
-	;exit: state stays as Open!
+; Check if handle matches.
+	CMP     R_scratch1, &rfid.handle                        ;[2]
+	JNE     exit_safely                                     ;[2] Handle doesn't match, so exit.
 
-	;Housekeeping: Restore saved CPU registers from before CRC16 call
-	POPM.A #1, R_byteCount;
+; Prepare rfid transmission buffer, CRC16 0-bit and handle.
+	MOV     (rfid.handle), R_scratch0                       ;[3] bring in the RN16
+	SWPB    R_scratch0                                      ;[1] swap bytes so we can shove full word out in one call (MSByte into dataBuf[0],...)
+	MOV     R_scratch0, &(rfidBuf)                          ;[3] load the MSByte
 
-	;/------------------------------------------------------------------------/
-	; Extract MEMBANK from middle of CMD[1] and store in register(?)
-	;/------------------------------------------------------------------------/
+	MOV     #(rfidBuf), R_scratch2                          ;[2] load &dataBuf[0] as dataPtr
+	MOV     #(2), R_scratch1                                ;[2] load num of bytes in ACK
 
-	MOV.B &(cmd+1), R_scratch0;
-	RRC R_scratch0; ; R_scratch0 >>= 6;
-	RRC R_scratch0;
-	RRC R_scratch0;
-	RRC R_scratch0;
-	RRC R_scratch0;
-	RRC R_scratch0;
-	AND #0x0003, R_scratch0; Mask off extra bits
-	MOV.B R_scratch0, &(RWData.memBank);
+	MOV     #ZERO_BIT_CRC, R12                              ;[2]
+	CALLA   #crc16_ccitt                                    ;[5+196]
 
-	;/------------------------------------------------------------------------/
-	; Shift majority of CMD buffer left by two bits to align data bytes
-	;/------------------------------------------------------------------------/
+	MOV.B   R12, &(rfidBuf+3)                               ;[3] store lower CRC byte first
+	SWPB    R12                                             ;[1] move upper byte into lower byte
+	MOV.B   R12, &(rfidBuf+2)                               ;[3] store upper CRC byte
 
-	;Shift buffer between CMD[1] and CMD[BC+7]
-	MOV #2, R_scratch0; Iterate through the following loop twice
-outerShiftLoop:
-	MOV R_byteCount, R_scratch1 ;Compute last valid byte address
-	ADD #7, R_scratch1
-	MOV #0, R_scratch2 ; This scratch register will help shuttle the carry
-innerShiftLoop:
-	BIT #1, R_scratch2; Move stored carry into actual carry
-	RLC.B cmd(R_scratch1); Rotate left with carry
-	CLR.W R_scratch2;
-	ADDC.B #0, R_scratch2; Store carry in R_scratch2
-	DEC R_scratch1;
-	JNZ innerShiftLoop; do...while(R_scratch1>0)
-	DEC R_scratch0;
-	JNZ outerShiftLoop; do...while(R_scratch0>0)
+	CLRC                                                    ;[3]
+	RRC.B   (rfidBuf)                                       ;[6]
+	RRC.B   (rfidBuf+1)                                     ;[6]
+	RRC.B   (rfidBuf+2)                                     ;[6]
+	RRC.B   (rfidBuf+3)                                     ;[6]
+	RRC.B   (rfidBuf+4)                                     ;[6]
 
-	;Now CMD[1]~CMD[BC+6] contain:
-	;{WP, WC, DATA[0], …, DATA[N-1], RN16[MSB], RN16[LSB], CRC16[MSB], CRC16[LSB]}
-	;And note that CMD[BC+7] is now invalid/unused
+; Wait for the rest of the BlockWrite command bits (CRC16).
+waitOnBits_5:
+	CMP.W   #74, R_bits                                     ;[2]
+	JLO     waitOnBits_5                                    ;[2]
 
-	;/------------------------------------------------------------------------/
-	; Check to see if handle matched
-	; TODO: This should be done before replying!
-	;/------------------------------------------------------------------------/
+; TODO: Figure out when we REALLY need to respond to the reader... commercial tags are not responding before they have written ALL words.
 
-	;First extract handle from CMD (spans two bytes)
-	MOV R_byteCount, R_scratch0
-	ADD #3, R_scratch0;
-	CLR.W R_scratch1;
-	MOV.B cmd(R_scratch0), R_scratch1;
-	SWPB R_scratch1;
-	INC R_scratch0;
-	MOV.B cmd(R_scratch0), R_scratch2;
-	BIS R_scratch2, R_scratch1;
-	;Now recovered handle is in R_scratch1. Leave if it’s not correct.
-	CMP R_scratch1, &(rfid.handle);
-	JNE exit_safely;
+; Reset cmd buffer.
+	MOV     #(cmd), R4                                      ;[] Now reset cmd buffer.
+	MOV     #(-3), R_bits                                   ;[] Prepare to parse frame sync.
+	CLR     R6                                              ;[] Clear the bitcount.
 
-	;/------------------------------------------------------------------------/
-	; Extract WP from CMD[1]
-	;/------------------------------------------------------------------------/
+; We are done... now disable interrupt and wait at least RTCAL*0.85 - 2us before sending (Table 6.16 EPC C1G2)
+	DINT                                                    ;[3]
+	NOP                                                     ;[1]
+	CLR     &TA0CTL                                         ;[4]
 
-	MOV &(cmd+1), &(RWData.wordPtr);
+; TCAL*0.85 - 2 us <= DELAY before response <= 20 ms
+call_my_BlockWriteCallback:
+	CMP.B       #(0), &(RWData.bwrHook)                     ;[4]
+	JEQ         move_timing_delay_BlockWrite                ;[2] If there is no user callback, wait before responding.
+	MOV         &(RWData.bwrHook), R_scratch0               ;[3]
+	CALLA       R_scratch0                                  ;[5]
 
-	;/------------------------------------------------------------------------/
-	; Set up and call user callback function
-	;/------------------------------------------------------------------------/
+; Just in case the user has no BlockWrite callback, we delay the response.
+move_timing_delay_BlockWrite:
+	MOV     #750, R_scratch0                                ;[2] Why is this value working for both readers? WTF happens during T5 anyway!?
 
-	MOV #(cmd+3), &(RWData.bwrBufPtr); Pointer to data buffer
-	MOV R_byteCount, &(RWData.bwrByteCount); Number of valid bytes in buffer
+timing_delay_for_BlockWrite:
+	DEC     R_scratch0                                      ;[1]
+	JNZ     timing_delay_for_BlockWrite                     ;[2]
 
-	;Note: Membank and writePtr (a.k.a. wordPtr) were previously loaded into RWData.memBank.
-	;RWData struct now contains results of blockwrite decoding
-	TST &(RWData.bwrHook);
-	JZ skipHookCall;
-	MOV &(RWData.bwrHook), R_scratch0;
-	CALLA R_scratch0;
-skipHookCall:
+respond_to_BlockWrite:
+	MOV     #rfidBuf, R12                                   ;[2] load the &rfidBuf[0]
+	MOV     #(4), R_scratch2                                ;[1] load into corr reg (numBytes)
+	MOV     #1, R_scratch1                                  ;[1] load numBits=1
+	MOV.B   #TREXT_ON, R_scratch0                           ;[3] load TRext
 
-	;User callback has finished execution.
+	CALLA   #TxFM0                                          ;[5] Send response.
 
-	;/------------------------------------------------------------------------/
-	; This has been a successful BlockWrite. Signal appropriately
-	;/------------------------------------------------------------------------/
+; TODO: In what order do we receive the words!? Figure out correct stop condition.
+; Experimental, breaks BlockWrite atm... pls fix.
+;blockwriteHandle_SkipHookCall:
+;	BIT.B	#(CMD_ID_BLOCKWRITE), (rfid.abortOn)            ;[] Should we abort on BlockWrite?
+;	JNZ		blockwriteHandle_BreakOutofRFID                 ;[]
+;	RETA                                                    ;[] else return w/o setting flag
 
-	;Modify abort flag if necessary
-	BIT.B #(CMD_ID_BLOCKWRITE), &(rfid.abortOn); Should we abort on BlockWrite?
-	JZ skipAbort
-	BIS.B #1, &(rfid.abortFlag); By setting this bit we’ll abort correctly
-skipAbort:
 
-	;/------------------------------------------------------------------------/
-	; Prepare to leave BlockWriteHandle
-	;/------------------------------------------------------------------------/
+;blockwriteHandle_BreakOutofRFID:
+;	BIS.B	#1, (rfid.abortFlag)                            ;[] by setting this bit we'll abort correctly!
+;	CALLA   #RxClock                                        ;[5+x] Switch to RxClock
+;	BIC     #(GIE), SR                                      ;[1] don't need anymore bits, so turn off Rx_SM
+;	NOP
+;	CLR     &TA0CTL
+;	RETA
+
 
 exit_safely:
-
-	; Tie up loose ends with timers and interrupts and such
-	DINT;
+	DINT
 	NOP;
 	CLR &TA0CTL;
-
-	; Switch back to RX clock mode
-
-	CALLA #RxClock	;Switch to Rx Clock
-
-	; Return to calling code
 	RETA;
-
 
 	.end

--- a/CCS/wisp-base/globals.h
+++ b/CCS/wisp-base/globals.h
@@ -121,7 +121,7 @@ typedef struct {
     uint8_t     wordPtr;                    /* for Rd/Wr, this will hold wordPtr parsed from cmd when hook is called            */
     uint16_t    wrData;                     /* for Write this will hold the 16-bit Write Data value when hook is called         */
     uint16_t    bwrByteCount;               /* for BlockWrite this will hold the number of BYTES received                       */
-    uint8_t*    bwrBufPtr;                  /* for BlockWrite this will hold a pointer to the data buffer containing write data */
+    uint16_t*    bwrBufPtr;                  /* for BlockWrite this will hold a pointer to the data buffer containing write data */
 
     //Function Hooks
     void*       *akHook;                    /* this function is called with no params or return after an ack command response   */

--- a/CCS/wisp-base/globals.h
+++ b/CCS/wisp-base/globals.h
@@ -43,20 +43,13 @@
 #define CMD_PARSE_AS_OVF                (0xFF)
 #define ENOUGH_BITS_TO_FORCE_EXECUTION  (200)
 
-#define RESET_BITS_VAL  (-1)        /* this is the value which will reset the TA1_SM if found in 'bits (R5)' by rfid_sm         */
+#define RESET_BITS_VAL  (-2)        /* this is the value which will reset the TA1_SM if found in 'bits (R5)' by rfid_sm         */
 
-//RFID TIMING DEFS                      /*4.08MHz                                                                                   */
-/** @todo map these better based on full range of valid vals!                                                                   */
-//Impinj Uses RTCal = 31.4us = 2.5*TARI (min possible.   RTCal goes between 2.5-3.0 TARI Per Spec)
-#define RTCAL_MIN       (2*85)
-#define RTCAL_NOM       (2*125)     /* (really only saw spread from 102 at high power to 96 at low power)                       */
-#define RTCAL_MAX       (2*150)     /*(this accounts for readers who use up to 3TARI, plus a little wiggle room)                */
-#define RTCAL_OFFS      (2*12)      /* see documentation for notes.                                                             */
-
-//Impinj Uses TRCal = 50.2us = 1.6*RTCAL(middle of road. TRCal goes between 1.1-3 RTCAL per spec. also said, 2.75-9.00 TARI)
-#define TRCAL_MIN       (2*140)
-#define TRCAL_NOM       (2*265)     /* (really only saw spread from 193 at high power to 192 at low power)                      */
-#define TRCAL_MAX       (2*451)     /* (this accounts for readers who use up to 9TARI)                                          */
+// RFID TIMINGS (Taken a bit more liberately to support both R420 and R1000).
+#define RTCAL_MIN                       (200)           // strictly calculated it should be 2.5*TARI = 2.5*6.25 = 15.625 us = 250 cycles
+#define RTCAL_MAX                       (300)           // 3*TARI = 3*6.25 = 18.75 us = 300 cycles
+#define TRCAL_MIN                       (220)           // We don't have time to do a MUL instruction, so we do 1.1*RTCAL_MIN instead of 1.1*RTCAL.
+#define TRCAL_MAX                       (900)           // We don't have time to do a MUL instruction, so we do 3*RTCAL_MAX instead of 3*RTCAL.
 
 //TIMING----------------------------------------------------------------------------------------------------------------------------//
 //Goal is 56.125/62.500/68.875us. Trying to shoot for the lower to save (a little) power.
@@ -70,8 +63,6 @@
 #define TX_TIMING_READ  (29)//58.0us
 #define TX_TIMING_WRITE (31)//60.4us
 
-#define FORCE_SKIP_INTO_RTCAL   (24)                    /* after delim, wait till data0 passes before starting TA1_SM. note     */
-                                                            /* changing this will affect timing criteria on RTCal measurement       */
 //PROTOCOL DEFS---------------------------------------------------------------------------------------------------------------------//
 //(if # is rounded to 8 that is so  cmd[n] was finished being shifted in)
 #define NUM_SEL_BITS    (48)    /* only need to parse through mask: (4+3+3+2+8+8+16 = 44 -> round to 48)                        */


### PR DESCRIPTION
With this pull request, I have (partially) rewritten/modified RX_ISR and Timer0A0_ISR  and documented it with the correct amount of cpu cycles each instruction takes. More importantly, it gets rid of the RTCAL_OFFS define and variable which was used to add an estimate value to the measured RTCAL since it was missing a PulseWidth (PW). With this pull request, Timer0A0 fires immediately after setting up Timer0A0, but returns after recording the falling edge (since it was detected in data-0 after the delimiter). Consequently, we also don't need FORCE_INTO_RTCAL delay anymore since we make Timer0A0 fire.

EDIT: Monday April 13:
Additionally the modifications for a working BlockWrite is also here. As a demo, I have also edited simpleAckDemo's my_blockWriteCallback to echo what exactly was written BlockWrite.
In the main(), you have to allocate some memory for RWData.bwrBufPtr. I have done this by allocating an array of 6 words to it. Of course this can be more, but for the sake of a demo I have chosen 6 because the EPC has 12 bytes = 6 words.

Note: This PR also fixes issue #13 

If you have any questions, feel free to ask :)