### PR TITLE
UART clock based on 32kHz ACLK

### DIFF
--- a/CCS/wisp-base/wired/uart.c
+++ b/CCS/wisp-base/wired/uart.c
@@ -23,22 +23,38 @@ struct {
 } UART_SM;
 
 /**
+ * Configure the internal clocks for UART transmission.
+ *
+ * @todo This is not a fix, it only hides the real problem. See UART_init() todo.
+ */
+void UART_setClock(void) {
+    CSCTL0_H = 0xA5;
+    CSCTL1 = DCORSEL + DCOFSEL_3; //8MHz
+    CSCTL2 = SELA_0 + SELM_3;
+    CSCTL2 |= SELS_3;
+    CSCTL3 = DIVA_0 + DIVS_0 + DIVM_0;
+}
+
+/**
  * Configure the eUSCI_A0 module in UART mode and prepare for UART transmission.
  *
- * @todo Currently assumes an 8MHz SMCLK. Make robust to clock frequency changes by using 32k ACLK.
+ * @todo Currently assumes (and enforces) an 8MHz SMCLK. Make robust to clock frequency changes by using 32k ACLK.
  */
 void UART_init(void) {
 
+    // Configure master clock
+    UART_setClock();
+
     // Configure USCI_A0 for UART mode
-    UCA0CTLW0 = UCSWRST;                      // Put eUSCI in reset
-    UCA0CTLW0 |= UCSSEL__SMCLK;               // CLK = SMCLK
+    UCA0CTLW0 = UCSWRST;          // Put eUSCI in reset
+    UCA0CTLW0 |= UCSSEL__SMCLK;   // CLK = SMCLK
 
     // Baud Rate calculation
     // 8000000/(16*9600) = 52.083
     // Fractional portion = 0.083
     // User's Guide Table 21-4: UCBRSx = 0x04
     // UCBRFx = int ( (52.083-52)*16) = 1
-    UCA0BR0 = 52;                             // 8000000/16/9600
+    UCA0BR0 = 52;                 // 8000000/16/9600
     UCA0BR1 = 0x00;
     UCA0MCTLW |= UCOS16 | UCBRF_1;
 
@@ -48,7 +64,7 @@ void UART_init(void) {
     PUART_RXSEL0 &= ~PIN_UART_RX; // RX pin to UART module
     PUART_RXSEL1 |= PIN_UART_RX;
 
-    UCA0CTLW0 &= ~UCSWRST;                    // Initialize eUSCI
+    UCA0CTLW0 &= ~UCSWRST;        // Initialize eUSCI
 
     // Initialize module state
     UART_SM.isTxBusy = FALSE;
@@ -56,7 +72,6 @@ void UART_init(void) {
     UART_SM.isRxBusy = FALSE;
     UART_SM.rxBytesRemaining = 0;
     UART_SM.rxTermChar = '\0';
-
 }
 
 /**

--- a/CCS/wisp-base/wired/uart.h
+++ b/CCS/wisp-base/wired/uart.h
@@ -11,6 +11,7 @@
 
 #include <stdint.h>
 
+void UART_setClock(void);
 void UART_init(void);
 
 void UART_asyncSend(uint8_t* txBuf, uint16_t size);


### PR DESCRIPTION
Hi all,

**Problem:** When using the UART functionality after running the ```do_RFID()```-function, the UART will not function correctly because the RFID stack changes some clock frequencies.
**Solution:** This problem could be solved by not having these components rely on the same clock.

The two commits in this PR serve a different purpose:
* The first commit hides the issue by resetting the clocks to their default values before using the UART
* The second commit tries to solve the issue by making the UART rely on the 32kHz ACLK

I'm not a huge fan of the former method, mainly because it hides the issue. On the other hand it might be good enough. Most important: it works.
The second method has my preference, this method unfortunately does not work. I checked the communications using an oscilloscope and I'm guessing this is due too the very large timing errors (which was already mentioned in the MSP430 manual Table 21-5).

**Disclaimer:** I do not think this PR can/should be merge now/anytime. Just informing you on this issue/progress.

Would like to hear some thoughts/opinions on this. 

--Ivar