### PR TITLE
Use ADC calibration values, remove magic numbers

### DIFF
--- a/CCS/wisp-base/Sensors/adc.h
+++ b/CCS/wisp-base/Sensors/adc.h
@@ -78,6 +78,7 @@ void ADC_asyncRead(void (*)(uint16_t));
 uint16_t ADC_critRead(void);
 
 // Conversion functions
+uint16_t ADC_rawCorrection(uint16_t);
 uint16_t ADC_rawToVoltage(uint16_t);
 int16_t ADC_rawToTemperature(uint16_t);
 


### PR DESCRIPTION
The MSP430 microcontrollers have per device calibration values stored in the TLV memory region.
See User Guide section 1.14.3 and MSP430 datasheet Table 6-62.

Instead of using magic numbers and self derived offset correction this code now uses these build in calibration values.
This should also make the ADC/temperature values more consistent across multiple WISPs (only tested with a few WISPs in a small temperature range).

Also set the voltage reference to be turned on automatically by the ADC instead of being constantly powered.

**Warning:** the convert to temperature function now returns milli Volts instead of deci Volts.

--Ivar